### PR TITLE
Joseph Yang / 2022 03 17 / 1문제

### DIFF
--- a/YYS/BOJ_14502.py
+++ b/YYS/BOJ_14502.py
@@ -1,0 +1,85 @@
+import copy
+from collections import deque
+
+# 설계 내용
+# 1. N,M 8칸 = 64 경우의 수 = (64x63x62)/(3x2) = 31x21x64 = 36000
+# 2. 0을 모두 후보에 넣고 백트래킹 방식 or 브루트 포스 depth 3
+
+N, M = list(map(int, input().split()))
+
+visit = []  # Boolean 배열만 사용
+start = []  # 바이러스 시작점 기록
+cnt = -3  # 0의 개수를 세어줌, 나중에 어차피 3을 빼므로 미리 뺸다
+
+for i in range(N):
+    arr = list(map(int, input().split()))
+    visit.append([False] * M)  # 맞는지 확인
+    for j in range(M):
+        if arr[j] == 2:
+            start.append([i, j])
+            visit[i][j] = True
+        elif arr[j] == 1:
+            visit[i][j] = True
+        elif arr[j] == 0:
+            cnt += 1
+
+depth = 0  # 기준 깊이
+
+# 일단 벽 3개 선택 메서드
+temp = []
+MAX = 0
+# 방향 배열
+dx = [0, 0, -1, 1]
+dy = [1, -1, 0, 0]
+
+
+# BFS 활용
+def spread(arr):
+    global cnt, start, dx, dy, MAX
+    count = cnt  # 세어줄 임시 count
+    q = deque()
+
+    for s in start:
+        q.append(s)
+
+    while len(q) != 0:
+        now = q.popleft()
+        row = now[0]
+        col = now[1]
+        arr[row][col] = True
+        for i in range(4):
+            r = row + dx[i]
+            c = col + dy[i]
+
+            # 가지치기
+            if r < 0 or r >= N or c < 0 or c >= M or arr[r][c]:
+                continue
+
+            count -= 1
+            arr[r][c] = True
+            q.append([r, c])
+    MAX = max(MAX, count)
+
+# 스도쿠 원리 이용
+def select(depth, row, col):
+    global visit, cnt, temp
+    if depth == 3:
+        spread(copy.deepcopy(visit))
+        return
+
+    if col >= M:
+        col = 0
+        row += 1
+    if row >= N:
+        return
+
+    if visit[row][col]:
+        select(depth, row, col + 1)
+    else:
+        visit[row][col] = True
+        select(depth + 1, row, col + 1)
+        visit[row][col] = False
+        select(depth, row, col + 1)
+
+select(0, 0, 0)
+print(MAX)


### PR DESCRIPTION
연구소)
도톨야 강사님의 강의를 듣고 설계 부분에서 메모리, 시간 복잡도를 미리 설계하려고 노력했습니다.
메모리 부분이 약한 것 같아서 이 부분을 먼저 구상해봤습니다.


공간 복잡도

* boolean - 1 byte, int - 4 byte

1. 배열의 크기는 최대 8X8이고 64칸을 차지할 수 있습니다. (boolean = 64 byte) (int = 256 byte)
2. 이 중에서 백트래킹 방식으로 3개의 벽을 구하는 경우의 수는 64C3 = 약 4만
        - 이 경우의 수마다 배열을 deepcopy 진행 = 4만 x 64byte = 2.5MB = INT 사용 가능
4. 3개의 벽을 구한 상태에서 BFS를 진행합니다.
       - 매번 큐를 만들어 바이러스 퍼짐을 구현하는데 메모리 사용은 미미합니다.


시간 복잡도

계산의 편의를 위해 n = 64로 둔다면 n*n*n/6 이 벽을 선택하는 경우의 수가 되고 이에 따른 벽의 움직임을 계산하는 작업은
4방위 탐색에 의해 nlog(n) 정도가 됩니다. n^4 log(n) 이지만 n이 최대 64로 매우 적고 많은 경우의 수가 있기 때문에 약 2천만으로 가정한다면 1초에 10억 연산을 가정해 2초에 빠듯하게 100문제를 풀 수 있습니다.